### PR TITLE
Allow manual trigger of workflows

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,8 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
+  # to trigger the workflow manually
+  workflow_dispatch:
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "main" ]
+  # to trigger the workflow manually
+  workflow_dispatch:
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Added an option to trigger both workflows manually, e.g. when I want to share new test results immediately after new tool versions are available